### PR TITLE
fix(deps): bump serde_with 3.15.0 -> 3.21.0 (GHSA-7gcf-g7xr-8hxj) [partial - alert stays open]

### DIFF
--- a/ZHMModSDK/Rust/Cargo.lock
+++ b/ZHMModSDK/Rust/Cargo.lock
@@ -186,6 +186,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -353,12 +362,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -377,11 +386,10 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -402,11 +410,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.21.3",
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.106",
 ]
@@ -628,7 +636,7 @@ dependencies = [
  "papaya",
  "serde",
  "serde_json",
- "serde_with 3.15.0",
+ "serde_with 3.21.0",
  "specta",
  "static_init",
  "thiserror 1.0.69",
@@ -1362,11 +1370,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.15.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6093cd8c01b25262b84927e0f7151692158fab02d961e04c979d3903eba7ecc5"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64 0.22.1",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -1375,7 +1384,7 @@ dependencies = [
  "schemars 1.0.4",
  "serde_core",
  "serde_json",
- "serde_with_macros 3.15.0",
+ "serde_with_macros 3.21.0",
  "time",
 ]
 
@@ -1393,11 +1402,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.15.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7e6c180db0816026a61afa1cff5344fb7ebded7e4d3062772179f2501481c27"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -1630,6 +1639,21 @@ dependencies = [
  "num-conv",
  "time-core",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml_datetime"


### PR DESCRIPTION
## Dependabot alert #4 — `serde_with` (medium) — **PARTIAL FIX, alert will NOT close**

**Advisory:** [GHSA-7gcf-g7xr-8hxj](https://github.com/advisories/GHSA-7gcf-g7xr-8hxj) — `KeyValueMap` serialization panics on empty sequence or map entries.
**Manifest:** `ZHMModSDK/Rust/Cargo.lock` (scope: runtime)
**Range:** `< 3.21.0` → patched `3.21.0`

### `Cargo.lock` carries TWO `serde_with` instances, and both are in range

| instance | dependency path | outcome |
|---|---|---|
| `serde_with 3.15.0` | `hitman-commons` → `quickentity-rs` → `zhmmodsdk_rs` | **FIXED → 3.21.0** |
| `serde_with 2.3.3` | `quickentity-rs` → `zhmmodsdk_rs` | **BLOCKED — no fix exists** |

### Why the 2.3.3 instance cannot be fixed from this repository

`quickentity-rs` is a **third-party git dependency pinned at rev `fc6d5fdd`**, and its `Cargo.toml` declares:

```toml
serde_with = "2.0.1"     # => >=2.0.1, <3
```

**2.3.3 is the newest published 2.x release.** The advisory range `< 3.21.0` therefore covers *every* 2.x release with no in-line remedy — there is no patched 2.x version to move to.

A rev bump does not help either: `quickentity-rs` at its **current upstream HEAD** (`2e7a3563`, 2026-06-26 — eight months newer than the pin) *still* declares `serde_with = "2.0.1"`. Closing this instance requires an upstream change in a third-party crate, then a rev bump here.

I also checked that this is not merely an over-broad advisory range: `KeyValueMap` **is** present in serde_with 2.3.3 (`src/key_value_map.rs`, 72 references), so the 2.x instance is genuinely affected.

### What this PR does and does not do

- **Does:** move the 3.x instance to 3.21.0, staying inside the 3.x major. Transitively this also updates `darling` 0.21.3 → 0.23.0 and adds `bs58`, `tinyvec`, `tinyvec_macros` (all pulled in by serde_with 3.21.0).
- **Does NOT:** close Dependabot alert #4 — the 2.3.3 instance remains in the vulnerable range.

### Verification

Local `cargo check` on this machine is **not a usable signal** and was not used: a standalone "Rust stable MSVC 1.91" install shadows the rustup nightly shim on `PATH`, so even nightly `cargo` invoked the stable `rustc` and the build failed on `#![feature]` inside `quickentity-rs`'s `auto_context` proc-macro crate (`E0554`) — a toolchain artifact unrelated to this change. This repository's `Build` workflow runs on `pull_request` with the nightly toolchain, so **CI is the authoritative check here.**
